### PR TITLE
fix system prompt, add python-dotenv to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai==0.27
 termcolor==2.2.0
 colorama
+python-dotenv

--- a/yolo.py
+++ b/yolo.py
@@ -115,13 +115,12 @@ if __name__ == "__main__":
       print ("No user prompt specified.")
       sys.exit(-1)
  
-  
   # Load the correct prompt based on Shell and OS and append the user's prompt
   prompt = get_full_prompt(user_prompt, shell)
 
   # Make the first line also the system prompt
-  system_prompt = prompt[1]
-
+  system_prompt = prompt.split("\n")[0]
+  
   # Call the ChatGPT API
   response = openai.ChatCompletion.create(
     model="gpt-3.5-turbo",


### PR DESCRIPTION
- Update the generation of the `system_prompt` as it only read in one character, rather then the entire first line of the `prompt.txt` file. Reading the first line was my original intent.

- Added python-dotenv to requirements.txt file- Added python-dotenv to requirements.txt file