### PR TITLE
wunderwuzzi23/gpt4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 ![Animated GIF](https://github.com/wunderwuzzi23/blog/raw/master/static/images/2023/yolo-shell-anim-gif.gif)
 
+# Update Yolo v0.2 - Support for GPT-4 API
+
+This update introduces the `yolo.yaml` configuration file. In this file you can specify which OpenAI model you want to query, and other settings. The safety switch also moved into this configuration file.
+
+For now the default model is still `gpt-3.5-turbo`, but you can update to `gpt-4` if you have gotten access already!
+
+```
+Yolo v0.2 - by @wunderwuzzi23
+
+Usage: yolo [-a] list the current directory information
+Argument: -a: Prompt the user before running the command (only useful when safety is off)
+
+Current configuration per yolo.yaml:
+* Model        : gpt-3.5-turbo
+* Temperature  : 0
+* Max. Tokens  : 500
+* Safety       : on
+```
+
+Happy Hacking!
+
 # Installation on Linux and macOS
 
 ```
@@ -17,17 +38,18 @@ yolo show me some funny unicode characters
 
 ## OpenAI API Key configuration
 
-There are two ways to configure the key on Linux and macOS:
+There are three ways to configure the key on Linux and macOS:
 - You can either `export OPENAI_API_KEY=<yourkey>`, or have a `.env` file in the same directory as `yolo.py` with `OPENAI_API_KEY="<yourkey>"` as a line
 - Create a file at `~/.openai.apikey` with the key in it
+- Add the key to the `yolo.yaml` configuration file
 
 ## Aliases
 
-To set the alias, like `yolo` or `computer` on each login, add them to your .bashrc or .bash_aliases file. (zsh on macOS)
+To set the alias, like `yolo` or `computer` on each login, add them to .bash_aliases (or .zshrc on macOS) file. Make sure the path is the one you want to use.
 
 ```
-echo "alias yolo=$TARGET_FULLPATH"     >> ~/.bash_aliases
-echo "alias computer=$TARGET_FULLPATH" >> ~/.bash_aliases
+echo "alias yolo=$(pwd)/yolo.py"     >> ~/.bash_aliases
+echo "alias computer=$(pwd)/yolo.py" >> ~/.bash_aliases
 ```
 
 ## Installation script
@@ -35,21 +57,20 @@ echo "alias computer=$TARGET_FULLPATH" >> ~/.bash_aliases
 Another option is to run `source install.sh` after cloning the repo. That does the following:
 1. Copies the necessary files to `~/yolo-ai-cmdbot/`
 2. Creates two aliases `yolo` and `computer` pointint to `~/yolo-ai-cmdbot/yolo.py`
-3. Adds the aliases to the `~/bash_aliases` file (only tested on Ubuntu)
+3. Adds the aliases to the `~/.bash_aliases` or `~/.zshrc` file
 
 That's it for Linux and macOS. Now make sure you have an OpenAI API key set.
 
-
 # Windows Installation
 
-On Windows run `.\install.bat` (or double-click) after cloning the repo. By default it does the following:
+On Windows you can run `.\install.bat` (or double-click) after cloning the repo. By default it does the following:
 1. Copies the necessary files to `~\yolo-ai-cmdbot\`
 2. Creates a `yolo.bat` file in `~` that lets you run equivalent to `python.exe ~\yolo-ai-cmdbot\yolo.py`
 
 You also have the option to:
 1. Change the location where `yolo-ai-cmdbot\` and `yolo.bat` will be created
 2. Skip creating `yolo-ai-cmdbot\` and use the folder of the cloned repository instead.
-3. Create a `.openai.apikey` and/or `.yolo-safety-off` file in your `~` directory
+3. Create a `.openai.apikey` file in your `~` directory
 
 That's it basically.
 
@@ -59,6 +80,8 @@ On Windows `export OPENAI_API_KEY=<yourkey>` will not work instead:
 - Run `$env:OPENAI_API_KEY="<yourkey>"` to set key for that terminal
 - Or, Run PowerShell as administrator and run `setx OPENAI_API_KEY "<yourkey>"`
 - Or, Go to `Start` and search `edit environment variables for your account` and manually create the variable with name `OPENAI_API_KEY` and value `<yourkey>`
+
+Optionally (since v.0.2), the key can also be stored in `yolo.yaml`.
 
 ## Running yolo on Windows 
 
@@ -88,13 +111,11 @@ Have fun.
 
 # Disabling the safety switch! **Caution!**
 
-By default `yolo` will prompt the user before executing commands. To have yolo run commands right away when they come back from ChatGPT create a file named `~/.yolo-safety-off`. 
+By default `yolo` will prompt the user before executing commands. 
 
-A simple command to do that on Linux would be:
+Since v.0.2 the safety switch setting moved to `yolo.yaml`, the old `~/.yolo-safety-off` is not used anymore. 
 
-```
-touch ~/.yolo-safety-off
-```
+To have yolo run commands right away when they come back from ChatGPT change the `safety` in the `yolo.yaml` to `False`.
 
 If you still want to inspect the command that is executed when safety is off, add the `-a` argument, e.g `yolo -a delete the file test.txt`.
 

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,42 @@
-# Installs yolo in the user's home directory
+# Simple installer for yolo in the user's home directory
 
+echo "Hello. Installing yolo..."
+echo "- Creating yolo-ai-cmdbot in home directory..."
 TARGET_DIR=~/yolo-ai-cmdbot
 TARGET_FULLPATH=$TARGET_DIR/yolo.py
-
 mkdir -p $TARGET_DIR
-cp yolo.py prompt.txt $TARGET_DIR
+
+echo "- Copying files..."
+cp yolo.py prompt.txt yolo.yaml $TARGET_DIR
 chmod +x $TARGET_FULLPATH
 
-#Linux/Mac
-
 # Creates two aliases for use
+echo "- Creating yolo and computer aliases..."
 alias yolo=$TARGET_FULLPATH
 alias computer=$TARGET_FULLPATH
 
 # Add the aliases to the logon scripts
-echo "alias yolo=$TARGET_FULLPATH"     >> ~/.bash_aliases
-echo "alias computer=$TARGET_FULLPATH" >> ~/.bash_aliases
+# Depends on your shell
+if [[ "$SHELL" == "/bin/bash" ]]; then
+  echo "- Adding aliases to ~/.bash_aliases"
+  echo "alias yolo=$TARGET_FULLPATH"     >> ~/.bash_aliases 
+  echo "alias computer=$TARGET_FULLPATH" >> ~/.bash_aliases
+elif [[ "$SHELL" == "/bin/zsh" ]]; then
+  echo "- Adding aliases to ~/.zshrc"
+  echo "alias yolo=$TARGET_FULLPATH"     >> ~/.zshrc 
+  echo "alias computer=$TARGET_FULLPATH" >> ~/.zshrc
+else
+  echo "Note: Shell was not bash or zsh."
+  echo "      Consider configuring aliases (like yolo and/or computer) manually by adding them to your login script, e.g:"
+  echo "      alias yolo=$TARGET_FULLPATH     >> <your_logon_file>"
+fi
+
+echo
+echo "Done."
+echo
+echo "Make sure you have the OpenAI API key set via one of these options:" 
+echo "  - environment variable"
+echo "  - .env or an ~/.openai.apikey file or in"
+echo "  - yolo.yaml"
+echo
+echo "Have fun!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 openai==0.27
 termcolor==2.2.0
-colorama
-python-dotenv
-distro
+colorama==0.4.4
+python-dotenv==1.0.0
+distro==1.7.0
+PyYAML==5.4.1

--- a/yolo.py
+++ b/yolo.py
@@ -161,7 +161,7 @@ res_command = response.choices[0].message.content.strip()
 #Enable color output on Windows using colorama
 init() 
 
-prefixes = ("sorry", "i'm sorry", "the question is not clear")
+prefixes = ("sorry", "i'm sorry", "the question is not clear", "i'm", "i am")
 if res_command.lower().startswith(prefixes):
   print(colored("There was an issue: "+res_command, 'red'))
   sys.exit(-1)

--- a/yolo.py
+++ b/yolo.py
@@ -11,20 +11,21 @@ import sys
 import subprocess
 import dotenv 
 import distro
+import yaml
 
 from termcolor import colored
 from colorama import init
 
-# Check if the user globally disabled the safety switch
-def get_yolo_safety_switch_config():
-  
-  home_path = os.path.expanduser("~")
-  yolo_safety_off_path = os.path.join(home_path,".yolo-safety-off")
-  
-  if os.path.exists(yolo_safety_off_path):
-    return False
-  else:
-    return True
+def read_config() -> any:
+
+  ## Find the executing directory (e.g. in case an alias is set)
+  ## So we can find the config file
+  yolo_path = os.path.abspath(__file__)
+  prompt_path = os.path.dirname(yolo_path)
+
+  config_file = os.path.join(prompt_path, "yolo.yaml")
+  with open(config_file, 'r') as file:
+    return yaml.safe_load(file)
 
 # Construct the prompt
 def get_full_prompt(user_prompt, shell):
@@ -48,12 +49,23 @@ def get_full_prompt(user_prompt, shell):
   return prompt
 
 def print_usage():
-  print("Yolo 0.1 - by @wunderwuzzi23")
+  print("Yolo v0.2 - by @wunderwuzzi23")
   print()
   print("Usage: yolo [-a] list the current directory information")
-  print("Argument: -a: Prompt the user before running the command")
+  print("Argument: -a: Prompt the user before running the command (only useful when safety is off)")
   print()
-  print("Current safety switch setting (~/.yolo-safety-off) is " + str(yolo_safety_switch))
+
+  yolo_safety_switch = "on"
+
+  if config["safety"] != True:
+    yolo_safety_switch = "off"
+  
+  print("Current configuration per yolo.yaml:")
+  print("* Model        : " + str(config["model"]))
+  print("* Temperature  : " + str(config["temperature"]))
+  print("* Max. Tokens  : " + str(config["max_tokens"]))
+  print("* Safety       : " + yolo_safety_switch)
+
 
 def get_os_friendly_name():
   
@@ -70,43 +82,50 @@ def get_os_friendly_name():
     return os_name
 
 
-if __name__ == "__main__":
-
-  # Get the global safety switch setting (default is True/on) 
-  yolo_safety_switch = get_yolo_safety_switch_config()
-
-  # Unix based SHELL (/bin/bash, /bin/zsh), otherwise assuming it's Windows
-  shell = os.environ.get("SHELL", "powershell.exe") 
-
-  command_start_idx  = 1      # Question starts at which argv index?
-  ask_flag = False           # safety switch -a command line argument
-  yolo = ""                  # user's answer to safety switch (-a) question y/n
-
-
+def set_api_key():
   # Two options for the user to specify they openai api key.
   #1. Place a ".env" file in same directory as this with the line:
   #   OPENAI_API_KEY="<yourkey>"
   #   or do `export OPENAI_API_KEY=<yourkey>` before use
   dotenv.load_dotenv()
   openai.api_key = os.getenv("OPENAI_API_KEY")
+  
   #2. Place a ".openai.apikey" in the home directory that holds the line:
   #   <yourkey>
+  #   Note: This options will likely be removed in the future
   if not openai.api_key:  #If statement to avoid "invalid filepath" error
     home_path = os.path.expanduser("~")    
     openai.api_key_path = os.path.join(home_path,".openai.apikey")
+
+  #3. Final option is the key might be in the yolo.yaml config file
+  #   openai_apikey: <yourkey>
+  if not openai.api_key:  
+    openai.api_key = config["openai_api_key"]
+
+if __name__ == "__main__":
+
+  config = read_config()
+  set_api_key()
+
+  # Unix based SHELL (/bin/bash, /bin/zsh), otherwise assuming it's Windows
+  shell = os.environ.get("SHELL", "powershell.exe") 
+
+  command_start_idx  = 1     # Question starts at which argv index?
+  ask_flag = False           # safety switch -a command line argument
+  yolo = ""                  # user's answer to safety switch (-a) question y/n
 
   # Parse arguments and make sure we have at least a single word
   if len(sys.argv) < 2:
     print_usage()
     sys.exit(-1)
 
-  # safety switch via argument -a (local override of global setting)
+  # Safety switch via argument -a (local override of global setting)
   # Force Y/n questions before running the command
   if sys.argv[1] == "-a":
     ask_flag = True
     command_start_idx = 2
 
-  # to allow easy/natural use we don't require the input to be a 
+  # To allow easy/natural use we don't require the input to be a 
   # single string. So, the user can just type yolo what is my name?
   # without having to put the question between ''
   arguments = sys.argv[command_start_idx:]
@@ -117,7 +136,6 @@ if __name__ == "__main__":
       print ("No user prompt specified.")
       sys.exit(-1)
  
-  
   # Load the correct prompt based on Shell and OS and append the user's prompt
   prompt = get_full_prompt(user_prompt, shell)
 
@@ -127,13 +145,13 @@ if __name__ == "__main__":
 
   # Call the ChatGPT API
   response = openai.ChatCompletion.create(
-    model="gpt-3.5-turbo",
+    model=config["model"],
     messages=[
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": prompt}
     ],
-    temperature=0,
-    max_tokens=500,
+    temperature=config["temperature"],
+    max_tokens=config["max_tokens"],
   )
 
 #print (response)
@@ -143,8 +161,8 @@ res_command = response.choices[0].message.content.strip()
 #Enable color output on Windows using colorama
 init() 
 
-prefixes = ("Sorry", "I'm sorry")
-if res_command.startswith(prefixes):
+prefixes = ("sorry", "i'm sorry", "the question is not clear")
+if res_command.lower().startswith(prefixes):
   print(colored("There was an issue: "+res_command, 'red'))
   sys.exit(-1)
 
@@ -154,8 +172,8 @@ if res_command.count("```",2):
   sys.exit(-1)
 
 print("Command: " + colored(res_command, 'blue'))
-if yolo_safety_switch == True or ask_flag == True:
-  print("Execute the command? Y/n (default Y) ==> ", end = '')
+if config["safety"] != "off" or ask_flag == True:
+  print("Execute the command? [Y/n] ==> ", end = '')
   yolo = input()
   print()
 

--- a/yolo.yaml
+++ b/yolo.yaml
@@ -1,0 +1,9 @@
+model: gpt-3.5-turbo  # If you have access to gpt-4 API already, you can update this.
+temperature: 0
+max_tokens: 500
+
+# Safety: If set to False, commands returned from the AI will be run *without* prompting the user.
+safety: True
+
+# Open AI API Key (optional): The key can aso be provided via environment variable (OPENAI_API_KEY), .env, or ~/.openai.apikey file
+openai_api_key:


### PR DESCRIPTION
- Adding GPT-4 support by introducing `yolo.yaml`, which allows to specify the model version and additional parameters. This can be extended in the future for other settings. Default is still `gpt-3.5-turbo` but can be set to `gpt-4` (if one has access).
- Removing the `~/.yolo-safety-off` file by placing the safety prompt configuration into the `yolo.yaml` file. (`safety: True` is the default).
- Updated the installers to copy the configuration file also
- Simplified some messages and added better output in installers

Noticed a bug that needs fixing: when running ./install.sh multiple times it will keep adding aliases to the file. Need to check if line was already added previously.


