### PR TITLE
add user actions for modifying prompt and copying to clipboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ colorama==0.4.4
 python-dotenv==1.0.0
 distro==1.7.0
 PyYAML==5.4.1
+pyperclip==1.8.2


### PR DESCRIPTION
Many thanks for the repo, fantastic idea! I added a couple features and I figured I'd share in case they were of interest.

I added two new actions to the selection prompt: modify and copy.

Modify allows you to re-enter a new prompt without exiting and copy copies to clipboard for future use or changes.

In order to implement the copy feature I added pyperclip as a dependency.

I also encapsulated some of the if statements into their own functions so they would be callable from the new modify action.

![example](https://user-images.githubusercontent.com/19663396/227117061-d04791a6-180a-4f39-b7f0-7c54cb559323.gif)
