### PR TITLE
added groq support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 ![Animated GIF](https://github.com/wunderwuzzi23/blog/raw/master/static/images/2023/yolo-shell-anim-gif.gif)
 
+# Update Yolo v0.4 - Support for Groq
+
+* Added groq support. You can get an API key at `https://console.groq.com` and set mode to for instance `llama3-8b-8192`. groq is lightning fast. 
+* Simplified and improved default `prompt.txt`, 
+* Note: Testing shows that model `gpt-4o` gives the best results.
+
+
 # Update Yolo v0.3 - Support for Azure OpenAI
 
 * Key changes are upgrades to the latest OpenAI libraries and support for Azure OpenAI. There is an `api` key in the `yolo.yaml` that can be set to `azure_openai` and then you can provide all the parameters accordingly in the yaml file as well (`api-version`, your `azure-endpoint`,...). The api key for azure is called `AZURE_OPENAI_API_KEY` by the way. It can be set via environment variable and config file.
@@ -59,6 +66,11 @@ There are three ways to configure the key on Linux and macOS:
 - You can either `export AZURE_OPENAI_API_KEY=<yourkey>`, or have a `.env` file in the same directory as `yolo.py` with `AZURE_OPENAI_API_KEY="<yourkey>"` as a line
 - Create a file at `~/.azureopenai.apikey` with the key in it
 - Set the key in the `yolo.yaml` configuration file
+
+### Groq Configuration
+- Grab an API key from `console.groq.com` 
+- You can either `export GROQ_API_KEY=<yourkey>`, or have a `.env` file in the same directory as `yolo.py` with `GROQ_API_KEY="<yourkey>"` as a line
+- Set `api` and `model` (e.g llama3-8b-8192) in `yolo.yaml` configuration file
 
 ## Aliases
 

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,29 +1,26 @@
-Act as a natural language to {shell} command translation engine on {os}. You are an expert in {shell} on {os} and translate the question at the end to valid syntax.
+You are Yolo, a natural language to {shell} command translation engine for {os}. You are an expert in {shell} on {os} and translate the question at the end to valid command line syntax.
 
-Follow these rules:
-Construct valid {shell} command that solve the question
-Leverage help and man pages to ensure valid syntax and an optimal solution
-Be concise 
-Just show the commands 
-Return only plaintext 
-Only show a single answer, but you can always chain commands together 
-Think step by step
-Only create valid syntax (you can use comments if it makes sense)
-If python is installed you can use it to solve problems
-if python3 is installed you can use it to solve problems
-Even if there is a lack of details, attempt to find the most logical solution by going about it step by step
-Do not return multiple solutions
-Do not show html, styled, colored formatting 
-Do not creating invalid syntax 
-Do not add unnecessary text in the response 
-Do not add notes or intro sentences 
-Do not show multiple distinct solutions to the question
-Do not add explanations on what the commands do
-Do not return what the question was 
-Do not repeat or paraphrase the question in your response 
-Do not cause syntax errors
-Do not rush to a conclusion
+Rules:
+* No code style markdown output, ever.
+* Construct valid {shell} command to solve the question
+* Leverage help and man pages to ensure valid syntax and an optimal solution
+* Be concise, think step by step, and show just final commands in plain text
+* Only show a single answer, but you can always chain commands together 
+* Create valid syntax of {shell} on {os}, include comments if useful
+* If python or python3 is installed you can use it to solve problems
+* Even if there is a lack of details, find the most logical solution by going about it step by step
+* Do not return multiple solutions
+* Do not show html, styled, colored formatting 
+* Do not create invalid syntax or cause syntax errors
+* Do not add unnecessary text in the response 
+* Do not add notes or intro sentences 
+* Do not show multiple distinct solutions to the question
+* Do not add explanations on what the commands do
+* Do not return what the question was 
+* Do not repeat or paraphrase the question in your response 
+* Do not rush to a conclusion
+* Never start a response with ```
 
-Follow all of the above rules. This is important you MUST follow the above rules. There are no exceptions to these rules. You must always follow them. No exceptions.
+Follow above rules. There are no exceptions to these rules. 
 
 Question: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.0.1
 distro==1.9.0
 PyYAML==6.0.1
 pyperclip==1.8.2
+groq==0.5.0

--- a/yolo.yaml
+++ b/yolo.yaml
@@ -1,4 +1,4 @@
-api: groq     # openai, azure_openai, groq         
+api: openai     # openai, azure_openai, groq         
 model: gpt-4o # if azure_openai this is the deployment name, for groq, e.g llama3-8b-8192
 
 # Azure specific (only needed if api: azure-openai)

--- a/yolo.yaml
+++ b/yolo.yaml
@@ -1,7 +1,5 @@
-api: openai # Set to azure_openai if you want to use Azure OpenAI API          
-
-# If you have access update to gpt-4 or gpt-4-turbo-preview, if Azure this is the deployment name
-model: gpt-4-turbo-preview 
+api: groq     # openai, azure_openai, groq         
+model: gpt-4o # if azure_openai this is the deployment name, for groq, e.g llama3-8b-8192
 
 # Azure specific (only needed if api: azure-openai)
 azure_endpoint: https://<name>.openai.azure.com
@@ -11,11 +9,13 @@ azure_api_version: 2024-02-15-preview
 temperature: 0
 max_tokens: 500
 
-safety: True # Safety: If set to False, commands returned from the AI will be run *without* prompting the user.
-modify: False # Enable prompt modify feature
+safety: True                  # Safety: If set to False, commands from LLM run *without* prompting the user.
+modify: False                 # Enable prompt modify feature
 suggested_command_color: blue # Suggested Command Color
 
-# API Keys (optional): The key can aso be provided via environment variable (OPENAI_API_KEY, AZURE_OPENAI_API_KEY), .env, or ~/.openai.apikey file
+# API Keys (optional): Preferred to use environment variables 
+# OPENAI_API_KEY, AZURE_OPENAI_API_KEY or GROQ_API_KEY (.env file is also supported)
 azure_openai_api_key: 
 openai_api_key:
+groq_api_key:
 


### PR DESCRIPTION
The following updates have beend made in v0.4:
* Added support fro groq.com. Head to `https://console.groq.com/keys` and `export GROQ_API_KEY=<your key>`
* Update the settings in the `yolo.yaml` accordingly to be self-explanatory on how to configure groq usage
* Made a couple of changes to the `prompt.txt` file
* Updated `README.md` accordingly

Overall, after using `yolo` for a while I believe  `gpt-4o` gives the best results. 
